### PR TITLE
fix/js: Add Deps, Compress JS, Fix Polyfills

### DIFF
--- a/build.js
+++ b/build.js
@@ -55,7 +55,18 @@ Metalsmith(__dirname)
           }
         }
       ]
-    }
+    },
+    plugins: [
+      new webpack.ProvidePlugin({
+        fetch: 'imports?this=>global!exports?global.fetch!whatwg-fetch'
+      }),
+      new webpack.optimize.DedupePlugin(),
+      new webpack.optimize.UglifyJsPlugin({
+        compress: {
+          warnings: false
+        }
+      })
+    ]
   }))
   .use(htmlMinifier())
   .build(err => { if (err) { console.log(err) }});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "babel-polyfill": "^6.5.0",
     "babel-runtime": "^6.5.0",
+    "es6-promise": "^3.1.2",
     "exports-loader": "^0.6.3",
     "imports-loader": "^0.6.5",
     "metalsmith": "^2.1.0",
@@ -20,14 +21,21 @@
     "metalsmith-layouts": "^1.4.2",
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-sass": "^1.3.0",
-    "tinyliquid": "^0.2.30"
+    "plotly.js": "^1.6.3",
+    "tinyliquid": "^0.2.30",
+    "whatwg-fetch": "^0.11.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.6.5",
     "babel-core": "^6.5.2",
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-runtime": "^6.5.2",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "eslint": "^2.3.0",
+    "eslint-config-google": "^0.4.0",
+    "metalsmith-babel": "^4.0.0",
+    "metalsmith-webpack": "^1.0.3",
     "underscore": "^1.8.3",
     "webpack": "^1.12.14"
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,4 @@
+require('es6-promise').polyfill();
 import plotly from 'plotly.js'
 import * as benchmarks from './lib/benchmarks.js'
 


### PR DESCRIPTION
Hey @MichaelHirn, I spend a few minutes and fixed your polyfill situation :smile: Safari is happy now!

I also got a bunch of errors because a lot of dependencies weren't declared and added them. (You should make sure to always use `npm install --save` or `--save-dev`.)

While I was at it, I also enabled JS minification for you. Your JS was previously 2.92MB (!) and is now 1.18MB (both before gzip -- plotly.js is _huge_).

Consider this a bit of free consulting work because you do awesome OpenSource stuff :smile: 

Fixes #2 
