### PR TITLE
Change Mozilla talk slide link to absolute link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -305,7 +305,7 @@ layout: index.liquid
               Refer to <a href="http://autumnai.github.io/leaf"><span class="label white radius font-color-light-blue">Leafs'</span></a> and
               <a href="http://autumnai.github.io/collenchyma"><span class="label white radius font-color-light-blue">Collenchymas'</span></a> documentation - btw you can
               <a class="no-underline white" href="https://github.com/autumnai/leaf/issues/45#issuecomment-189409309">help us create a higher-level documentation for the community</a>. Or browse through our
-              <a href="www.slideshare.net/MichaelJHirn/machine-learning-in-rust-with-leaf-and-collenchyma"><span class="label white radius font-color-light-blue">Mozilla talk slides</span></a>.
+              <a href="http://www.slideshare.net/MichaelJHirn/machine-learning-in-rust-with-leaf-and-collenchyma"><span class="label white radius font-color-light-blue">Mozilla talk slides</span></a>.
             </p>
           </div>
         </div>


### PR DESCRIPTION
The browser (at least chromium) believes that `www.slideshare.net/...` is a relative link.
